### PR TITLE
feat: Organizationのenumを追加する

### DIFF
--- a/src/Domain/Object/OrganizationManageTest.php
+++ b/src/Domain/Object/OrganizationManageTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Domain\Object;
+
+use PHPUnit\Framework\TestCase;
+
+class OrganizationManageTest extends TestCase
+{
+    public function testOrganizationManage(){
+        $manage = OrganizationManager::getOrganization("0");
+        $this->assertEquals($manage, Organization::MANAGE);
+    }
+
+    public function testOrganizationProduct(){
+        $product = OrganizationManager::getOrganization("1");
+        $this->assertEquals($product, Organization::PRODUCT);
+    }
+}

--- a/src/Domain/Object/OrganizationManager.php
+++ b/src/Domain/Object/OrganizationManager.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Domain\Object;
+
+class OrganizationManager
+{
+    public static function getOrganization(?string $organizationId): ?Organization
+    {
+        if (empty($organizationId)) {
+            return null;
+        }
+        return Organization::tryFrom($organizationId);
+    }
+}
+
+enum Organization: string
+{
+    case MANAGE = "0";
+    case PRODUCT= "1";
+    case DEVELOPER = "2";
+    case INFRA = "3";
+}


### PR DESCRIPTION
Organizationのenumを追加しました。

ただし、 `php unit` テストを行ったところ、以下のエラーになりました。

``` console
$ ./vendor/bin/phpunit src   
PHPUnit 11.3.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.18

F.                                                                  2 / 2 (100%)

Time: 00:00.014, Memory: 8.00 MB

There was 1 failure:

1) App\Domain\Object\OrganizationManageTest::testOrganizationManage
App\Domain\Object\Organization Enum (MANAGE, '0') does not match expected type "NULL".

/Users/usr7000326/git/php-sample/src/Domain/Object/OrganizationManageTest.php:11

FAILURES!
Tests: 2, Assertions: 2, Failures: 1.
```

どこを修正したらいいのか教えてほしいです。